### PR TITLE
DOCSINFRA-103 Exchange name went wrong : AppExchange -> Anypoint Exchange

### DIFF
--- a/modules/ROOT/pages/tools.adoc
+++ b/modules/ROOT/pages/tools.adoc
@@ -3,7 +3,7 @@ ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]
 
-Anypoint Monitoring 通知を外部システムに配信しやすくするために、Anypoint Monitoring では AppExchange のコネクタへのリンクを提供し、Mule アプリケーションに追加できるようにしています。
+Anypoint Monitoring 通知を外部システムに配信しやすくするために、Anypoint Monitoring では Anypoint Exchange のコネクタへのリンクを提供し、Mule アプリケーションに追加できるようにしています。
 
 .Anypoint Monitoring で使用可能なツール
 image::tools.png[ツール]


### PR DESCRIPTION
Probably in translation process, a wrong transforming was mixed up.